### PR TITLE
Color Bool-values green/red (no diff)

### DIFF
--- a/runner/src/exercism_test_runner/internal.gleam
+++ b/runner/src/exercism_test_runner/internal.gleam
@@ -83,17 +83,35 @@ fn print_properties(
 pub fn print_error(error: Error, path: String, test_name: String) -> String {
   case error {
     Unequal(left, right) -> {
-      let diff =
-        gap.to_styled(gap.compare_strings(
-          string.inspect(left),
-          string.inspect(right),
-        ))
+      let #(left_colored, right_colored) = case
+        #(dynamic.bool(left), dynamic.bool(right))
+      {
+        #(Ok(left_bool), Ok(right_bool)) -> #(
+          left_bool
+          |> string.inspect()
+          |> ansi.green()
+          |> ansi.bold(),
+          right_bool
+          |> string.inspect()
+          |> ansi.red()
+          |> ansi.bold(),
+        )
+        _ -> {
+          let diff =
+            gap.to_styled(gap.compare_strings(
+              string.inspect(left),
+              string.inspect(right),
+            ))
+          #(diff.first, diff.second)
+        }
+      }
+
       path
       |> print_properties([
         #("test", test_name),
         #("error", "left != right"),
-        #("left", diff.first),
-        #("right", diff.second),
+        #("left", left_colored),
+        #("right", right_colored),
       ])
     }
     Todo(message) -> {


### PR DESCRIPTION
Made Bool-values a special case which opts out of gap-diffing and highlights the whole word green/red.

Before:
<img width="522" alt="Screenshot 2023-07-26 at 11 38 12" src="https://github.com/exercism/gleam-test-runner/assets/1716064/88dbc92e-0c86-4540-b783-9d4274da9a0b">

After:
<img width="514" alt="Screenshot 2023-07-26 at 12 21 33" src="https://github.com/exercism/gleam-test-runner/assets/1716064/f5e4696b-5fe4-4f22-89f7-0213c5499f03">

*NOTE*: A lot of tests in the exercises use `let assert` to assert boolean values. These would need to change to `should.equal` to benefit from this change. I can do a separate PR agains the gleam-track repo if this gets merged.