### PR TITLE
Bump version to v0.31.0

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM ghcr.io/gleam-lang/gleam:v0.30.5-erlang-alpine
+FROM ghcr.io/gleam-lang/gleam:v0.31.0-erlang-alpine
 
 # Install packages required to run the tests
 RUN apk add --no-cache jq coreutils
@@ -11,7 +11,6 @@ COPY . .
 # compiling test projects.
 RUN cd packages \
   && gleam deps download \
-  && gleam fix build/packages --target erlang \
   && gleam build
 
 ENTRYPOINT ["/opt/test-runner/bin/run.sh"]


### PR DESCRIPTION
Hello, I've noticed that the Gleam "pipelines" on Exercism don't use the latest version because I was trying to use a feature from that version to solve one of the exercises and it failed.

Here's a version lift MR. Hope I haven't missed something 🤞 